### PR TITLE
Add support for local npm prefix

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -35,6 +35,8 @@ function getInstallationPath(callback) {
 
       if (env && env.npm_config_prefix) {
         dir = join(env.npm_config_prefix, 'bin');
+      } else if (env && env.npm_config_local_prefix) {
+        dir = join(env.npm_config_local_prefix, join('node_modules', '.bin'));
       } else {
         return callback(new Error('Error finding binary installation directory'));
       }


### PR DESCRIPTION
This pull request adds support for the `npm_config_local_prefix` environment variable as well as the `npm_config_prefix` one documented [here](https://github.com/npm/cli/blob/a5fec08/docs/lib/content/commands/npm.md#directories).

This enables submodules to work with a Go binary:
```
const path = require('path');
const { spawn } = require('child_process');

spawn(`${path.dirname(require.main.filename)}/node_modules/.bin/binary`);
```