### PR TITLE
Add support for `pnpm`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@go-task/go-npm",
       "version": "0.1.16",
       "license": "Apache-2.0",
+      "dependencies": {
+        "used-pm": "^1.0.0"
+      },
       "bin": {
         "go-npm": "bin/index.js"
       },
@@ -1898,7 +1901,7 @@
     "node_modules/block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
       "dev": true,
       "dependencies": {
         "inherits": "~2.0.0"
@@ -7975,6 +7978,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "deprecated": "This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.",
       "dev": true,
       "dependencies": {
         "block-stream": "*",
@@ -8250,6 +8254,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/used-pm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/used-pm/-/used-pm-1.0.0.tgz",
+      "integrity": "sha512-imCruP1jKlraI8MgwRYg1gvduqYN1MKe8pfcdX34gx8LfO8JxhVTv6r7LtRvIWOBtamys3+7QEZTMb0ZccHXiQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/mheob"
       }
     },
     "node_modules/util-deprecate": {
@@ -10023,7 +10035,7 @@
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
       "dev": true,
       "requires": {
         "inherits": "~2.0.0"
@@ -15131,6 +15143,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "used-pm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/used-pm/-/used-pm-1.0.0.tgz",
+      "integrity": "sha512-imCruP1jKlraI8MgwRYg1gvduqYN1MKe8pfcdX34gx8LfO8JxhVTv6r7LtRvIWOBtamys3+7QEZTMb0ZccHXiQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/go-task/go-npm.git"
   },
   "homepage": "https://github.com/go-task/go-npm",
+  "dependencies": {
+    "used-pm": "^1.0.0"
+  },
   "devDependencies": {
     "esbuild": "^0.12.17",
     "jest": "^24.5.0",

--- a/src/common.js
+++ b/src/common.js
@@ -2,6 +2,7 @@ const { join } = require('path');
 const { exec } = require('child_process');
 const { existsSync, readFileSync } = require('fs');
 const mkdirp = require('mkdirp');
+const usedPM =require('used-pm');
 
 // Mapping from Node's `process.arch` to Golang's `$GOARCH`
 const ARCH_MAPPING = {
@@ -33,10 +34,16 @@ function getInstallationPath(callback) {
       // Ex: /Users/foo/.nvm/versions/node/v4.3.0
       const env = process.env;
 
+      // Get the package manager who is running the script
+      // This is needed since PNPM works in a different way than NPM or YARN.
+      const packageManager = usedPM();
+
       if (env && env.npm_config_prefix) {
         dir = join(env.npm_config_prefix, 'bin');
       } else if (env && env.npm_config_local_prefix) {
         dir = join(env.npm_config_local_prefix, join('node_modules', '.bin'));
+      } else if (packageManager.name.toLowerCase() === 'pnpm') {
+        dir = join(process.cwd(), 'node_modules', '.bin');
       } else {
         return callback(new Error('Error finding binary installation directory'));
       }


### PR DESCRIPTION
An external script ([usedPM](https://github.com/mheob/used-pm)) is added to check which package manager starts the execution.
With this it is possible to find out which package manager is used.
We can now simply check for `pnpm` and use the `node_modules` folder of the project.

Resolves #2