### PR TITLE
Install global bin to the correct location on windows

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -39,7 +39,13 @@ function getInstallationPath(callback) {
       const packageManager = usedPM();
 
       if (env && env.npm_config_prefix) {
-        dir = join(env.npm_config_prefix, 'bin');
+        if (process.platform === 'win32') {
+          // On Windows, use the installation directory itself instead of the `bin` folder.
+          // See: https://docs.npmjs.com/cli/v6/configuring-npm/folders#executables
+          dir = env.npm_config_prefix;
+        } else {
+          dir = join(env.npm_config_prefix, 'bin');
+        }
       } else if (env && env.npm_config_local_prefix) {
         dir = join(env.npm_config_local_prefix, join('node_modules', '.bin'));
       } else if (packageManager.name.toLowerCase() === 'pnpm') {


### PR DESCRIPTION
On Windows, the globally installed CLI is placed in the `%npm_config_prefix%` directory, not the `%npm_config_prefix%\bin` directory.

> When in global mode, executables are linked into `{prefix}/bin` on Unix,
> or directly into `{prefix}` on Windows.  Ensure that path is in your
> terminal's `PATH` environment to run them.
> --- https://github.com/npm/cli/blob/1e977eec223463b04a6ad2c1953e31a6d5d22f2c/docs/lib/content/configuring-npm/folders.md?plain=1#L55-L57

This pull request fixes a bug that did not conform to this behavior.

- [x] Fix bugs
- [x] Add tests for behavior changes

Closes https://github.com/go-task/go-npm/issues/4